### PR TITLE
Updated peer dependency to allow installation in react 18 projects and added license file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 React Canvas Recorder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">=16.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-canvas-recorder",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Canvas Element Recorder for React, with really simple API",
   "keywords": ["react", "canvas", "canvas-recorder", "canvas animation", "animation recorder" ],
   "author": "rasha08",


### PR DESCRIPTION
I've tested this library in a React 18 project, and it works, but I had to `--force` the installation. To address this, I've implemented the following changes:

- Changed the peerDependency for React to be '>=16.0.0' instead of '^16.0.0'. I think this will be enough to enable installation in React 18 projects without requiring the '--force' flag.
- Added a license file to make it more visible on the GitHub page.
- Updated the version number in 'package.json' to 1.1.2 to prevent issues during 'npm publish.'

If you find these changes acceptable, would you please review, test, and approve this PR? Once approved, you could upload the new version to npm using 'npm publish', so people could use this library without having to `--force` the install.

Thank you!